### PR TITLE
解决上传小文件失败后重试的若干问题

### DIFF
--- a/syncdata/operation/upload.go
+++ b/syncdata/operation/upload.go
@@ -121,6 +121,7 @@ func (p *Uploader) Upload(file string, key string) (err error) {
 		log.Println("open file failed: ", file, err)
 		return err
 	}
+	defer f.Close()
 
 	fInfo, err := f.Stat()
 	if err != nil {

--- a/syncdata/operation/upload.go
+++ b/syncdata/operation/upload.go
@@ -69,7 +69,7 @@ func (p *Uploader) UploadData(data []byte, key string) (err error) {
 	return
 }
 
-func (p *Uploader) UploadDataReader(data io.Reader, size int, key string) (err error) {
+func (p *Uploader) UploadDataReader(data io.ReadSeeker, size int, key string) (err error) {
 	t := time.Now()
 	defer func() {
 		log.Println("up time ", key, time.Now().Sub(t))
@@ -101,6 +101,10 @@ func (p *Uploader) UploadDataReader(data io.Reader, size int, key string) (err e
 			break
 		}
 		log.Println("small upload retry", i, err)
+		_, err = data.Seek(0, io.SeekStart)
+		if err != nil {
+			return
+		}
 	}
 	return
 }
@@ -150,6 +154,10 @@ func (p *Uploader) Upload(file string, key string) (err error) {
 				break
 			}
 			log.Println("small upload retry", i, err)
+			_, err = f.Seek(0, io.SeekStart)
+			if err != nil {
+				return
+			}
 		}
 		return
 	}


### PR DESCRIPTION
1. 解决文件打开后不关闭造成文件句柄泄漏的问题
2. 解决小文件在上传失败后，文件被关闭，无法再次重新上传的问题
3. 解决小文件在上传失败后，文件已经被读取到末尾，没有 rewind 导致无法再次重新上传的问题