### PR TITLE
上传 request body 不再使用 ReadSeeker，可能会有 data race 风险

### DIFF
--- a/syncdata/cmd/up/main.go
+++ b/syncdata/cmd/up/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"log"
-	"os"
 
 	"github.com/qiniupd/qiniu-go-sdk/syncdata/operation"
 )
@@ -20,14 +19,6 @@ func main() {
 
 	up := operation.NewUploader(x)
 
-	file, err := os.Open(*f)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	defer file.Close()
-
-	err = up.UploadReader(file, *f)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	err = up.Upload(*f, *f)
+	log.Fatalln(err)
 }


### PR DESCRIPTION
ReadSeeker can be used, but some users have observed occasional data races between the net/http library and the Seek functionality of some implementations of ReadSeeker, so should be avoided if possible.