### PR TITLE
调整 api.v8 接口，让所有方法都遵循来自 initParts API 返回的建议分片大小

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+env.sh

--- a/syncdata/operation/upload.go
+++ b/syncdata/operation/upload.go
@@ -210,7 +210,7 @@ func (p *Uploader) UploadReaderWithContext(ctx context.Context, reader io.Reader
 		})
 	}
 
-	return uploader.StreamUpload(ctx, ret, upToken, key, io.MultiReader(bytes.NewReader(firstPart), bufReader),
+	return uploader.StreamUpload(ctx, ret, upToken, key, io.MultiReader(bytes.NewReader(firstPart), bufReader), nil,
 		func(partIdx int, etag string) {
 			elog.Info("upload", key, "callback", "part:", partIdx, "etag:", etag)
 		})


### PR DESCRIPTION
同时所有上传方法都允许传入 CompleteMultipart，可用于设置文件名，元数据等信息